### PR TITLE
[Fix] Clickable go back on stepper

### DIFF
--- a/ui/src/Components/Stepper.js
+++ b/ui/src/Components/Stepper.js
@@ -20,16 +20,15 @@ export const Stepper = ({
         size={isMobile ? "sm" : "md"}
         orientation="horizontal"
         variant="circles-alt"
+        onClickStep={(stepIndex) =>
+          currentCategoryIndex > stepIndex && setCurrentCategoryIndex(stepIndex)
+        }
       >
         {categories.map((category, index) => (
           <Step
             key={index}
             label={category}
-            onClick={() => currentCategoryIndex > index && setCurrentCategoryIndex(index)}
             isCompletedStep={index < currentCategoryIndex || isTemoignageSent ? true : false}
-            style={{
-              cursor: currentCategoryIndex > index ? "pointer" : "initial",
-            }}
           >
             {children}
           </Step>

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -34,6 +34,20 @@ const CustomSteps = {
       },
     },
   },
+  variants: {
+    "circles-alt": (props) => {
+      console.log(Steps.variants["circles-alt"](props).step);
+      return {
+        ...Steps.variants["circles-alt"](props),
+        step: {
+          ...Steps.variants["circles-alt"](props).step,
+          _highlighted: {
+            cursor: "pointer!important",
+          },
+        },
+      };
+    },
+  },
 };
 
 export const theme = extendTheme({


### PR DESCRIPTION
After upgrading the `chakra-ui-steps` lib, steps were not clickable anymore. This PR fixes it.