### PR TITLE
[Serveur] Ajoute le champ onisep_initule dans la DAO `findAllWithTemoignageCount`

### DIFF
--- a/extension/sirius-onisep-injector/chrome/popup.js
+++ b/extension/sirius-onisep-injector/chrome/popup.js
@@ -21,8 +21,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }} )
     .then(response => response.json())
     .then(data => {
+      console.log({data})
       const formationLink = document.getElementById('formation-link');
       data.forEach(item => {
+        console.log({item})
         if(item.temoignagesCount < 1) return;
         if(item.onisepIntitule === null) return;
         const li = document.createElement('li');

--- a/server/src/dao/formations.dao.ts
+++ b/server/src/dao/formations.dao.ts
@@ -293,6 +293,7 @@ export const findAllWithTemoignageCount = async (): Promise<Partial<Formation>[]
       sql<number>`COUNT(DISTINCT temoignages_campagnes.temoignage_id) FILTER (WHERE temoignages_campagnes.temoignage_id IS NOT NULL)`.as(
         "temoignagesCount"
       ),
+      sql<string>`catalogue_data->>'onisep_intitule'`.as("onisep_intitule"),
     ])
     .leftJoin("campagnes", "campagnes.id", "formations.campagne_id")
     .leftJoin("temoignages_campagnes", "temoignages_campagnes.campagne_id", "formations.campagne_id")


### PR DESCRIPTION
Ce champs manquant cassait l'extension.